### PR TITLE
Removed need for JSON-LD string manipulation during serialization 

### DIFF
--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -167,13 +167,9 @@ class BaseModel implements SerializerInterface, TypeCheckerInterface
     public static function serialize($obj)
     {
         // Get data ready to be encoded
-        $data = JsonLdHelper::prepareDataForSerialization($obj);
+        $data = JsonLdHelper::prepareDataForSerialization($obj, null);
 
-        // Add context - this will get the called class's context
-
-        $json = json_encode($data);
-
-        return JsonLdHelper::removeAllButFirstContext($json);
+        return json_encode($data);
     }
 
     public function __get($name)

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -167,7 +167,7 @@ class BaseModel implements SerializerInterface, TypeCheckerInterface
     public static function serialize($obj)
     {
         // Get data ready to be encoded
-        $data = JsonLdHelper::prepareDataForSerialization($obj, null);
+        $data = JsonLdHelper::prepareDataForSerialization($obj);
 
         return json_encode($data);
     }

--- a/src/Rpde/RpdeBody.php
+++ b/src/Rpde/RpdeBody.php
@@ -333,7 +333,7 @@ class RpdeBody implements SerializerInterface, TypeCheckerInterface
      */
     public static function serialize($obj)
     {
-        $data = JsonLdHelper::prepareDataForSerialization($obj, null);
+        $data = JsonLdHelper::prepareDataForSerialization($obj);
 
         return json_encode($data);
     }

--- a/src/Rpde/RpdeBody.php
+++ b/src/Rpde/RpdeBody.php
@@ -333,11 +333,9 @@ class RpdeBody implements SerializerInterface, TypeCheckerInterface
      */
     public static function serialize($obj)
     {
-        $data = JsonLdHelper::prepareDataForSerialization($obj);
+        $data = JsonLdHelper::prepareDataForSerialization($obj, null);
 
-        $json = json_encode($data);
-
-        return JsonLdHelper::removeAllButFirstContext($json);
+        return json_encode($data);
     }
 
     /**


### PR DESCRIPTION
This approach removes JSON-LD string manipulation after having serialized the data.

This is achieved by better using recursion (passing the parent down as well as the main value to serialize) when traversing all the data.