### PR TITLE
Validate times

### DIFF
--- a/src/Models/OA/OpeningHoursSpecification.php
+++ b/src/Models/OA/OpeningHoursSpecification.php
@@ -23,7 +23,7 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\OpeningHour
      * "closes": "17:00"
      * ```
      *
-     * @var DateTime|null
+     * @var string|null
      */
     protected $closes;
 
@@ -45,12 +45,12 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\OpeningHour
      * "opens": "09:00"
      * ```
      *
-     * @var DateTime|null
+     * @var string|null
      */
     protected $opens;
 
     /**
-     * @return DateTime|null
+     * @return string|null
      */
     public function getCloses()
     {
@@ -58,14 +58,14 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\OpeningHour
     }
 
     /**
-     * @param DateTime|null $closes
+     * @param string|null $closes
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setCloses($closes)
     {
         $types = array(
-            "DateTime",
+            "Time",
             "null",
         );
 
@@ -100,7 +100,7 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\OpeningHour
     }
 
     /**
-     * @return DateTime|null
+     * @return string|null
      */
     public function getOpens()
     {
@@ -108,14 +108,14 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\OpeningHour
     }
 
     /**
-     * @param DateTime|null $opens
+     * @param string|null $opens
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setOpens($opens)
     {
         $types = array(
-            "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/OA/Schedule.php
+++ b/src/Models/OA/Schedule.php
@@ -74,7 +74,7 @@ class Schedule extends \OpenActive\BaseModel
      * "endTime": "12:00:00"
      * ```
      *
-     * @var DateTime|null
+     * @var string|null
      */
     protected $endTime;
 
@@ -169,7 +169,7 @@ class Schedule extends \OpenActive\BaseModel
      * "startTime": "12:00:00"
      * ```
      *
-     * @var DateTime|null
+     * @var string|null
      */
     protected $startTime;
 
@@ -286,7 +286,7 @@ class Schedule extends \OpenActive\BaseModel
     }
 
     /**
-     * @return DateTime|null
+     * @return string|null
      */
     public function getEndTime()
     {
@@ -294,14 +294,14 @@ class Schedule extends \OpenActive\BaseModel
     }
 
     /**
-     * @param DateTime|null $endTime
+     * @param string|null $endTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setEndTime($endTime)
     {
         $types = array(
-            "DateTime",
+            "Time",
             "null",
         );
 
@@ -484,7 +484,7 @@ class Schedule extends \OpenActive\BaseModel
     }
 
     /**
-     * @return DateTime|null
+     * @return string|null
      */
     public function getStartTime()
     {
@@ -492,14 +492,14 @@ class Schedule extends \OpenActive\BaseModel
     }
 
     /**
-     * @param DateTime|null $startTime
+     * @param string|null $startTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setStartTime($startTime)
     {
         $types = array(
-            "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/SchemaOrg/Action.php
+++ b/src/Models/SchemaOrg/Action.php
@@ -29,7 +29,7 @@ class Action extends \OpenActive\Models\SchemaOrg\Thing
      * Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
      *
      *
-     * @var DateTime|null
+     * @var string|DateTime|null
      */
     protected $startTime;
 
@@ -63,7 +63,7 @@ class Action extends \OpenActive\Models\SchemaOrg\Thing
      * Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
      *
      *
-     * @var DateTime|null
+     * @var string|DateTime|null
      */
     protected $endTime;
 
@@ -132,7 +132,7 @@ class Action extends \OpenActive\Models\SchemaOrg\Thing
     }
 
     /**
-     * @return DateTime|null
+     * @return string|DateTime|null
      */
     public function getStartTime()
     {
@@ -140,13 +140,14 @@ class Action extends \OpenActive\Models\SchemaOrg\Thing
     }
 
     /**
-     * @param DateTime|null $startTime
+     * @param string|DateTime|null $startTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setStartTime($startTime)
     {
         $types = array(
+            "Time",
             "DateTime",
             "null",
         );
@@ -231,7 +232,7 @@ class Action extends \OpenActive\Models\SchemaOrg\Thing
     }
 
     /**
-     * @return DateTime|null
+     * @return string|DateTime|null
      */
     public function getEndTime()
     {
@@ -239,13 +240,14 @@ class Action extends \OpenActive\Models\SchemaOrg\Thing
     }
 
     /**
-     * @param DateTime|null $endTime
+     * @param string|DateTime|null $endTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setEndTime($endTime)
     {
         $types = array(
+            "Time",
             "DateTime",
             "null",
         );

--- a/src/Models/SchemaOrg/ActionAccessSpecification.php
+++ b/src/Models/SchemaOrg/ActionAccessSpecification.php
@@ -19,7 +19,7 @@ class ActionAccessSpecification extends \OpenActive\Models\SchemaOrg\Intangible
      * The beginning of the availability of the product or service included in the offer.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $availabilityStarts;
 
@@ -43,7 +43,7 @@ class ActionAccessSpecification extends \OpenActive\Models\SchemaOrg\Intangible
      * The end of the availability of the product or service included in the offer.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $availabilityEnds;
 
@@ -66,7 +66,7 @@ class ActionAccessSpecification extends \OpenActive\Models\SchemaOrg\Intangible
     protected $eligibleRegion;
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getAvailabilityStarts()
     {
@@ -74,7 +74,7 @@ class ActionAccessSpecification extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @param DateTime|null $availabilityStarts
+     * @param DateTime|string|null $availabilityStarts
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -82,6 +82,7 @@ class ActionAccessSpecification extends \OpenActive\Models\SchemaOrg\Intangible
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 
@@ -143,7 +144,7 @@ class ActionAccessSpecification extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getAvailabilityEnds()
     {
@@ -151,7 +152,7 @@ class ActionAccessSpecification extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @param DateTime|null $availabilityEnds
+     * @param DateTime|string|null $availabilityEnds
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -159,6 +160,7 @@ class ActionAccessSpecification extends \OpenActive\Models\SchemaOrg\Intangible
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/SchemaOrg/Demand.php
+++ b/src/Models/SchemaOrg/Demand.php
@@ -27,7 +27,7 @@ class Demand extends \OpenActive\Models\SchemaOrg\Intangible
      * The beginning of the availability of the product or service included in the offer.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $availabilityStarts;
 
@@ -179,7 +179,7 @@ class Demand extends \OpenActive\Models\SchemaOrg\Intangible
      * The end of the availability of the product or service included in the offer.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $availabilityEnds;
 
@@ -290,7 +290,7 @@ class Demand extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getAvailabilityStarts()
     {
@@ -298,7 +298,7 @@ class Demand extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @param DateTime|null $availabilityStarts
+     * @param DateTime|string|null $availabilityStarts
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -306,6 +306,7 @@ class Demand extends \OpenActive\Models\SchemaOrg\Intangible
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 
@@ -752,7 +753,7 @@ class Demand extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getAvailabilityEnds()
     {
@@ -760,7 +761,7 @@ class Demand extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @param DateTime|null $availabilityEnds
+     * @param DateTime|string|null $availabilityEnds
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -768,6 +769,7 @@ class Demand extends \OpenActive\Models\SchemaOrg\Intangible
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/SchemaOrg/Event.php
+++ b/src/Models/SchemaOrg/Event.php
@@ -92,7 +92,7 @@ class Event extends \OpenActive\Models\SchemaOrg\Thing
      * The time admission will commence.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $doorTime;
 
@@ -625,7 +625,7 @@ class Event extends \OpenActive\Models\SchemaOrg\Thing
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getDoorTime()
     {
@@ -633,7 +633,7 @@ class Event extends \OpenActive\Models\SchemaOrg\Thing
     }
 
     /**
-     * @param DateTime|null $doorTime
+     * @param DateTime|string|null $doorTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -641,6 +641,7 @@ class Event extends \OpenActive\Models\SchemaOrg\Thing
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/SchemaOrg/FoodEstablishmentReservation.php
+++ b/src/Models/SchemaOrg/FoodEstablishmentReservation.php
@@ -21,7 +21,7 @@ class FoodEstablishmentReservation extends \OpenActive\Models\SchemaOrg\Reservat
      * Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
      *
      *
-     * @var DateTime|null
+     * @var string|DateTime|null
      */
     protected $startTime;
 
@@ -31,7 +31,7 @@ class FoodEstablishmentReservation extends \OpenActive\Models\SchemaOrg\Reservat
      * Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
      *
      *
-     * @var DateTime|null
+     * @var string|DateTime|null
      */
     protected $endTime;
 
@@ -44,7 +44,7 @@ class FoodEstablishmentReservation extends \OpenActive\Models\SchemaOrg\Reservat
     protected $partySize;
 
     /**
-     * @return DateTime|null
+     * @return string|DateTime|null
      */
     public function getStartTime()
     {
@@ -52,13 +52,14 @@ class FoodEstablishmentReservation extends \OpenActive\Models\SchemaOrg\Reservat
     }
 
     /**
-     * @param DateTime|null $startTime
+     * @param string|DateTime|null $startTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setStartTime($startTime)
     {
         $types = array(
+            "Time",
             "DateTime",
             "null",
         );
@@ -69,7 +70,7 @@ class FoodEstablishmentReservation extends \OpenActive\Models\SchemaOrg\Reservat
     }
 
     /**
-     * @return DateTime|null
+     * @return string|DateTime|null
      */
     public function getEndTime()
     {
@@ -77,13 +78,14 @@ class FoodEstablishmentReservation extends \OpenActive\Models\SchemaOrg\Reservat
     }
 
     /**
-     * @param DateTime|null $endTime
+     * @param string|DateTime|null $endTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setEndTime($endTime)
     {
         $types = array(
+            "Time",
             "DateTime",
             "null",
         );

--- a/src/Models/SchemaOrg/LodgingBusiness.php
+++ b/src/Models/SchemaOrg/LodgingBusiness.php
@@ -27,7 +27,7 @@ class LodgingBusiness extends \OpenActive\Models\SchemaOrg\LocalBusiness
      * The earliest someone may check into a lodging establishment.
      *
      *
-     * @var DateTime|null
+     * @var string|DateTime|null
      */
     protected $checkinTime;
 
@@ -67,7 +67,7 @@ class LodgingBusiness extends \OpenActive\Models\SchemaOrg\LocalBusiness
      * The latest someone may check out of a lodging establishment.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $checkoutTime;
 
@@ -105,7 +105,7 @@ class LodgingBusiness extends \OpenActive\Models\SchemaOrg\LocalBusiness
     }
 
     /**
-     * @return DateTime|null
+     * @return string|DateTime|null
      */
     public function getCheckinTime()
     {
@@ -113,13 +113,14 @@ class LodgingBusiness extends \OpenActive\Models\SchemaOrg\LocalBusiness
     }
 
     /**
-     * @param DateTime|null $checkinTime
+     * @param string|DateTime|null $checkinTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setCheckinTime($checkinTime)
     {
         $types = array(
+            "Time",
             "DateTime",
             "null",
         );
@@ -229,7 +230,7 @@ class LodgingBusiness extends \OpenActive\Models\SchemaOrg\LocalBusiness
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getCheckoutTime()
     {
@@ -237,7 +238,7 @@ class LodgingBusiness extends \OpenActive\Models\SchemaOrg\LocalBusiness
     }
 
     /**
-     * @param DateTime|null $checkoutTime
+     * @param DateTime|string|null $checkoutTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -245,6 +246,7 @@ class LodgingBusiness extends \OpenActive\Models\SchemaOrg\LocalBusiness
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/SchemaOrg/LodgingReservation.php
+++ b/src/Models/SchemaOrg/LodgingReservation.php
@@ -19,7 +19,7 @@ class LodgingReservation extends \OpenActive\Models\SchemaOrg\Reservation
      * The earliest someone may check into a lodging establishment.
      *
      *
-     * @var DateTime|null
+     * @var string|DateTime|null
      */
     protected $checkinTime;
 
@@ -43,7 +43,7 @@ class LodgingReservation extends \OpenActive\Models\SchemaOrg\Reservation
      * The latest someone may check out of a lodging establishment.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $checkoutTime;
 
@@ -64,7 +64,7 @@ class LodgingReservation extends \OpenActive\Models\SchemaOrg\Reservation
     protected $numAdults;
 
     /**
-     * @return DateTime|null
+     * @return string|DateTime|null
      */
     public function getCheckinTime()
     {
@@ -72,13 +72,14 @@ class LodgingReservation extends \OpenActive\Models\SchemaOrg\Reservation
     }
 
     /**
-     * @param DateTime|null $checkinTime
+     * @param string|DateTime|null $checkinTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setCheckinTime($checkinTime)
     {
         $types = array(
+            "Time",
             "DateTime",
             "null",
         );
@@ -139,7 +140,7 @@ class LodgingReservation extends \OpenActive\Models\SchemaOrg\Reservation
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getCheckoutTime()
     {
@@ -147,7 +148,7 @@ class LodgingReservation extends \OpenActive\Models\SchemaOrg\Reservation
     }
 
     /**
-     * @param DateTime|null $checkoutTime
+     * @param DateTime|string|null $checkoutTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -155,6 +156,7 @@ class LodgingReservation extends \OpenActive\Models\SchemaOrg\Reservation
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/SchemaOrg/MediaObject.php
+++ b/src/Models/SchemaOrg/MediaObject.php
@@ -21,7 +21,7 @@ class MediaObject extends \OpenActive\Models\SchemaOrg\CreativeWork
      * Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
      *
      *
-     * @var DateTime|null
+     * @var string|DateTime|null
      */
     protected $startTime;
 
@@ -79,7 +79,7 @@ class MediaObject extends \OpenActive\Models\SchemaOrg\CreativeWork
      * Note that Event uses startDate/endDate instead of startTime/endTime, even when describing dates with times. This situation may be clarified in future revisions.
      *
      *
-     * @var DateTime|null
+     * @var string|DateTime|null
      */
     protected $endTime;
 
@@ -160,7 +160,7 @@ class MediaObject extends \OpenActive\Models\SchemaOrg\CreativeWork
     protected $encodingFormat;
 
     /**
-     * @return DateTime|null
+     * @return string|DateTime|null
      */
     public function getStartTime()
     {
@@ -168,13 +168,14 @@ class MediaObject extends \OpenActive\Models\SchemaOrg\CreativeWork
     }
 
     /**
-     * @param DateTime|null $startTime
+     * @param string|DateTime|null $startTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setStartTime($startTime)
     {
         $types = array(
+            "Time",
             "DateTime",
             "null",
         );
@@ -333,7 +334,7 @@ class MediaObject extends \OpenActive\Models\SchemaOrg\CreativeWork
     }
 
     /**
-     * @return DateTime|null
+     * @return string|DateTime|null
      */
     public function getEndTime()
     {
@@ -341,13 +342,14 @@ class MediaObject extends \OpenActive\Models\SchemaOrg\CreativeWork
     }
 
     /**
-     * @param DateTime|null $endTime
+     * @param string|DateTime|null $endTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setEndTime($endTime)
     {
         $types = array(
+            "Time",
             "DateTime",
             "null",
         );

--- a/src/Models/SchemaOrg/Offer.php
+++ b/src/Models/SchemaOrg/Offer.php
@@ -27,7 +27,7 @@ class Offer extends \OpenActive\Models\SchemaOrg\Intangible
      * The beginning of the availability of the product or service included in the offer.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $availabilityStarts;
 
@@ -247,7 +247,7 @@ class Offer extends \OpenActive\Models\SchemaOrg\Intangible
      * The end of the availability of the product or service included in the offer.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $availabilityEnds;
 
@@ -383,7 +383,7 @@ class Offer extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getAvailabilityStarts()
     {
@@ -391,7 +391,7 @@ class Offer extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @param DateTime|null $availabilityStarts
+     * @param DateTime|string|null $availabilityStarts
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -399,6 +399,7 @@ class Offer extends \OpenActive\Models\SchemaOrg\Intangible
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 
@@ -1018,7 +1019,7 @@ class Offer extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getAvailabilityEnds()
     {
@@ -1026,7 +1027,7 @@ class Offer extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @param DateTime|null $availabilityEnds
+     * @param DateTime|string|null $availabilityEnds
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -1034,6 +1035,7 @@ class Offer extends \OpenActive\Models\SchemaOrg\Intangible
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/SchemaOrg/OpeningHoursSpecification.php
+++ b/src/Models/SchemaOrg/OpeningHoursSpecification.php
@@ -35,7 +35,7 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\StructuredV
      * The opening hour of the place or service on the given day(s) of the week.
      *
      *
-     * @var DateTime|null
+     * @var string|null
      */
     protected $opens;
 
@@ -43,7 +43,7 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\StructuredV
      * The closing hour of the place or service on the given day(s) of the week.
      *
      *
-     * @var DateTime|null
+     * @var string|null
      */
     protected $closes;
 
@@ -106,7 +106,7 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\StructuredV
     }
 
     /**
-     * @return DateTime|null
+     * @return string|null
      */
     public function getOpens()
     {
@@ -114,14 +114,14 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\StructuredV
     }
 
     /**
-     * @param DateTime|null $opens
+     * @param string|null $opens
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setOpens($opens)
     {
         $types = array(
-            "DateTime",
+            "Time",
             "null",
         );
 
@@ -131,7 +131,7 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\StructuredV
     }
 
     /**
-     * @return DateTime|null
+     * @return string|null
      */
     public function getCloses()
     {
@@ -139,14 +139,14 @@ class OpeningHoursSpecification extends \OpenActive\Models\SchemaOrg\StructuredV
     }
 
     /**
-     * @param DateTime|null $closes
+     * @param string|null $closes
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
     public function setCloses($closes)
     {
         $types = array(
-            "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Models/SchemaOrg/Trip.php
+++ b/src/Models/SchemaOrg/Trip.php
@@ -35,7 +35,7 @@ class Trip extends \OpenActive\Models\SchemaOrg\Intangible
      * The expected arrival time.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $arrivalTime;
 
@@ -43,7 +43,7 @@ class Trip extends \OpenActive\Models\SchemaOrg\Intangible
      * The expected departure time.
      *
      *
-     * @var DateTime|null
+     * @var DateTime|string|null
      */
     protected $departureTime;
 
@@ -97,7 +97,7 @@ class Trip extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getArrivalTime()
     {
@@ -105,7 +105,7 @@ class Trip extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @param DateTime|null $arrivalTime
+     * @param DateTime|string|null $arrivalTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -113,6 +113,7 @@ class Trip extends \OpenActive\Models\SchemaOrg\Intangible
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 
@@ -122,7 +123,7 @@ class Trip extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @return DateTime|null
+     * @return DateTime|string|null
      */
     public function getDepartureTime()
     {
@@ -130,7 +131,7 @@ class Trip extends \OpenActive\Models\SchemaOrg\Intangible
     }
 
     /**
-     * @param DateTime|null $departureTime
+     * @param DateTime|string|null $departureTime
      * @return void
      * @throws \OpenActive\Exceptions\InvalidArgumentException If the provided argument is not of a supported type.
      */
@@ -138,6 +139,7 @@ class Trip extends \OpenActive\Models\SchemaOrg\Intangible
     {
         $types = array(
             "DateTime",
+            "Time",
             "null",
         );
 

--- a/src/Validators/BaseValidator.php
+++ b/src/Validators/BaseValidator.php
@@ -69,6 +69,10 @@ class BaseValidator implements ValidatorInterface
             return new DateIntervalValidator();
         }
 
+        if ($type === "Time") {
+            return new TimeValidator();
+        }
+
         // If type is an OpenActive Enum
         if (strpos($type, "\\OpenActive\\Enums") === 0) {
             return new EnumValidator($type);

--- a/src/Validators/TimeValidator.php
+++ b/src/Validators/TimeValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenActive\Validators;
+
+class TimeValidator extends BaseValidator
+{
+    /**
+     * Run validation on the given value.
+     *
+     * @param mixed $value The value to validate.
+     * @return bool Whether validation passes or not.
+     */
+    public function run($value)
+    {
+        if(!is_string($value))
+            return false;
+        // user DateTime to parse the string to check it it a valid time string
+        // alas it will add today's date so this created object cannot
+        $dateTimeFormat = "H:i:s";
+        $time = \DateTime::createFromFormat($dateTimeFormat, $value);
+
+        return $time !== false;
+    }
+}

--- a/src/Validators/TimeValidator.php
+++ b/src/Validators/TimeValidator.php
@@ -12,8 +12,9 @@ class TimeValidator extends BaseValidator
      */
     public function run($value)
     {
-        if(!is_string($value))
+        if(!is_string($value)) {
             return false;
+        }
         // user DateTime to parse the string to check it it a valid time string
         // alas it will add today's date so this created object cannot
         $dateTimeFormat = "H:i:s";

--- a/tests/Unit/Validators/TimeValidatorTest.php
+++ b/tests/Unit/Validators/TimeValidatorTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit\Validators;
+
+use OpenActive\Validators\TimeValidator;
+use PHPUnit\Framework\TestCase;
+
+class TimeValidatorTest extends TestCase
+{
+    public function testValidTimeReturnsTrue()
+    {
+        assert((new TimeValidator())->run("12:00:00"), "TimeValidator should allow valid ISO 8601 times");
+    }
+
+    public function testInvalidTimeReturnsFalse()
+    {
+        assert(!(new TimeValidator())->run("not a time"), "TimeValidator should disallow invalid ISO 8601 times");
+    }
+}
+
+?>


### PR DESCRIPTION
Allow properties to check against a TimeValidator but be stored in PHP as strings (because there is no Time object just a DateTime).

This includes the updates from running the generator changes in https://github.com/openactive/models-lib/pull/18 to set some properties as Time-types.