### PR TITLE
Moved setting of attributes to defineProperty method for consistency.

### DIFF
--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -117,7 +117,13 @@ class BaseModel implements SerializerInterface, TypeCheckerInterface
         // so that it gets converted from array to object
         // (associative arrays are still arrays in PHP)
         if (array_key_exists("type", $value)) {
-            $classname = "\\OpenActive\\Models\\OA\\".$value["type"];
+            // If type is schema.org target right namespace
+            if(strpos($value["type"], "schema:") === 0) {
+                $classname = "\\OpenActive\\Models\\SchemaOrg\\".
+                    str_replace("schema:", "", $value["type"]);
+            } else {
+                $classname = "\\OpenActive\\Models\\OA\\".$value["type"];
+            }
 
             return $classname::deserialize($value);
         }

--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -52,11 +52,28 @@ class BaseModel implements SerializerInterface, TypeCheckerInterface
     public function __construct($data)
     {
         foreach ($data as $key => $value) {
-            // Make sure attribute is cased properly
-            $attributeName = Str::camel($key);
-
-            $this->$attributeName = static::deserializeValue($value);
+            $this->defineProperty($key, $value);
         }
+    }
+
+    public function defineProperty($key, $value)
+    {
+        // Don't try to set "@context" or type
+        if ($key === "@context" || $key === "type") {
+            return;
+        }
+
+        // Build setter name
+        $setterName = "set" . Str::pascal($key);
+
+        // Calling the setter will type-enforce the values
+
+        if (is_array($value)) {
+            $this->$setterName(static::deserializeValue($value));
+            return;
+        }
+
+        $this->$setterName($value);
     }
 
     /**

--- a/src/Concerns/Serializer.php
+++ b/src/Concerns/Serializer.php
@@ -59,17 +59,7 @@ trait Serializer
         }
 
         foreach ($data as $key => $value) {
-            $attrName = Str::camel($key);
-            $setterName = "set" . Str::pascal($key);
-
-            if (is_object($value)) {
-                $self->$attrName = $value::deserialize($value);
-            } elseif (is_array($value)) {
-                $self->$attrName = static::deserializeValue($value);
-            } elseif ($key !== "@context" && $key !== "type") {
-                // Calling the setter will type-enforce it
-                $self->$setterName($value);
-            }
+            $self->defineProperty($key, $value);
         }
 
         return $self;


### PR DESCRIPTION
As highlighted by @ylt deserialization, and in general object instantiation, was leading to inconsistent assignment of attributes depending on type. This PR aims at bringing one single point where this are defined.
I've used `defineProperty` as a opposed to `setProperty` (used by Ruby implementation), to avoid confusion within regular model setters.