### PR TITLE
Add support for injecting in schema.org `@context`

### DIFF
--- a/src/Concerns/Serializer.php
+++ b/src/Concerns/Serializer.php
@@ -12,11 +12,12 @@ trait Serializer
      *
      * @param object $obj The given instance to convert to JSON-LD
      * @param bool $prettyPrint Whether to pretty-print the JSON-LD output
+     * @param bool $schema Whether to add a Schema.org context
      * @return string JSON-LD string representation of the given instance.
      */
-    public static function serialize($obj, $prettyPrint = false)
+    public static function serialize($obj, $prettyPrint = false, $schema = false)
     {
-        $data = static::toArray($obj);
+        $data = static::toArray($obj, $schema);
 
         if($prettyPrint === true) {
             return json_encode($data, JSON_PRETTY_PRINT);
@@ -29,12 +30,12 @@ trait Serializer
      * Returns the JSON-LD associative array representation of the given instance.
      *
      * @param object $obj The given instance to convert to JSON-LD
-     * @param bool $prettyPrint Whether to pretty-print the JSON-LD output
+     * @param bool $schema Whether to add a Schema.org context
      * @return array JSON-LD associative array representation of the given instance.
      */
-    public static function toArray($obj)
+    public static function toArray($obj, $schema = false)
     {
-        return JsonLdHelper::prepareDataForSerialization($obj);
+        return JsonLdHelper::prepareDataForSerialization($obj, null, $schema);
     }
 
     /**

--- a/src/Helpers/JsonLd.php
+++ b/src/Helpers/JsonLd.php
@@ -22,9 +22,10 @@ class JsonLd
      *
      * @param \OpenActive\BaseModel $obj The given instance to convert to JSON-LD
      * @param object|null $parent The parent node in the structure.
+     * @param bool $schema Whether to add a Schema.org context
      * @return array
      */
-    public static function prepareDataForSerialization($obj, $parent = null)
+    public static function prepareDataForSerialization($obj, $parent = null, $schema = false)
     {
         // Get fully qualified namespace of the object's class name
         $fq_classname = "\\".get_class($obj);
@@ -62,7 +63,10 @@ class JsonLd
                 )
             )
         ) {
-            $data["@context"] = static::$defaultContext;
+            $data["@context"] = array_merge(
+                $schema ? ['https://schema.org'] : [],
+                static::$defaultContext
+            );
         }
 
         $fields = $obj->fieldList();
@@ -85,7 +89,8 @@ class JsonLd
 
                         $item = self::prepareDataForSerialization(
                             $item,
-                            $attrValue
+                            $attrValue,
+                            $schema
                         );
                     }
 
@@ -100,7 +105,8 @@ class JsonLd
 
                 $attrValue = self::prepareDataForSerialization(
                     $attrValue,
-                    $obj
+                    $obj,
+                    $schema
                 );
             }
 

--- a/tests/Unit/ExampleEventTest.php
+++ b/tests/Unit/ExampleEventTest.php
@@ -92,6 +92,24 @@ class ExampleEventTest extends TestCase
     }
 
     /**
+     * Test that serialization and deserialization return the same result (but with @ prefixes added)
+     * after the process.
+     *
+     * @return void
+     */
+    public function testSchemaContext()
+    {
+        $original = "{\"@context\":[\"https:\\/\\/openactive.io\\/\",\"https:\\/\\/openactive.io\\/ns-beta\"],\"@type\":\"Concept\",\"@id\":\"https://openactive.io/facility-types#37bbed12-270b-42b1-9af2-70f0273990dd\",\"prefLabel\":\"Grass\",\"inScheme\":\"https://openactive.io/facility-types\"}";
+
+        $decode = Concept::deserialize($original);
+        $encode = Concept::serialize($decode, false, true);
+
+        $decoded = json_decode($encode, true);
+
+        $this->assertContains("https://schema.org", $decoded["@context"]);
+    }
+
+    /**
      * A basic test example.
      *
      * @return void


### PR DESCRIPTION
Wasn't sure on the best way of implementing this on the PHP end, hopefully this is good?

Equivalent code on the Ruby side: https://github.com/openactive/models-ruby/pull/17/files#diff-0f6288f82c43eadee64ccdfd5f2e0b1bL32-L59