### PR TITLE
Enum validation now supports Enum objects

### DIFF
--- a/src/Helpers/JsonLd.php
+++ b/src/Helpers/JsonLd.php
@@ -41,6 +41,11 @@ class JsonLd
             return DateTimeHelper::iso8601($obj);
         }
 
+        // Enums should return memberVal const
+        if(strpos($fq_classname, "\\OpenActive\\Enums\\") === 0) {
+            return $obj::memberVal;
+        }
+
         $data = array();
 
         // Add type to data if not an RpdeItem

--- a/src/Validators/EnumValidator.php
+++ b/src/Validators/EnumValidator.php
@@ -39,11 +39,14 @@ class EnumValidator extends BaseValidator
         if (is_object($value)) {
             $reflection = new \ReflectionClass($value);
 
+            $classname = $reflection->getName();
+
             $memberVal = $reflection->getConstant('memberVal');
 
             if (
                 $memberVal === false ||
-                $reflection->getConstant('value') === false
+                $reflection->getConstant('value') === false ||
+                strpos($classname, 'OpenActive\Enums\\') === 0
             ) {
                 return false;
             }

--- a/src/Validators/EnumValidator.php
+++ b/src/Validators/EnumValidator.php
@@ -2,6 +2,8 @@
 
 namespace OpenActive\Validators;
 
+use ReflectionClass;
+
 class EnumValidator extends BaseValidator
 {
     public function __construct($classname)
@@ -30,12 +32,32 @@ class EnumValidator extends BaseValidator
      */
     public function run($value)
     {
+        if (! is_string($value) && ! is_object($value)) {
+            return false;
+        }
+
+        if (is_object($value)) {
+            $reflection = new \ReflectionClass($value);
+
+            $memberVal = $reflection->getConstant('memberVal');
+
+            if (
+                $memberVal === false ||
+                $reflection->getConstant('value') === false
+            ) {
+                return false;
+            }
+
+            $value = $value::memberVal;
+        }
+
         // Enum value is usually in a URL form
         // Replace the base so that have a classname to use for the enum value
         $enumValueClassname = str_replace(
             array(
                 "https://openactive.io/ns-beta#",
                 "https://openactive.io/",
+                "https://schema.org/",
             ),
             "",
             $value

--- a/src/Validators/EnumValidator.php
+++ b/src/Validators/EnumValidator.php
@@ -25,19 +25,7 @@ class EnumValidator extends BaseValidator
             return $value;
         }
 
-        // Enum value is usually in a URL form
-        // Replace the base so that have a classname to use for the enum value
-        $enumValueClassname = str_replace(
-            array(
-                "https://openactive.io/ns-beta#",
-                "https://openactive.io/",
-                "https://schema.org/",
-            ),
-            "",
-            $value
-        );
-
-        $fqEnumClassname = $this->classname."\\".$enumValueClassname;
+        $fqEnumClassname = $this->getFullQualifiedEnumClassname($value);
 
         return new $fqEnumClassname();
     }
@@ -72,6 +60,23 @@ class EnumValidator extends BaseValidator
             $value = $memberVal;
         }
 
+        $fqEnumClassname = $this->getFullQualifiedEnumClassname($value);
+
+        // $this->classname also represents the root namespace
+        // of the enum value classname,
+        // if a class with that namespace plus its name exists
+        // and has the same value passed to the validator, pass!
+        return class_exists($fqEnumClassname) &&
+            $fqEnumClassname::memberVal === $value;
+    }
+
+    /**
+     * Return the fully-qualified Enum classname from a given URL value
+     *
+     * @return string
+     */
+    private function getFullQualifiedEnumClassname($url)
+    {
         // Enum value is usually in a URL form
         // Replace the base so that have a classname to use for the enum value
         $enumValueClassname = str_replace(
@@ -81,16 +86,9 @@ class EnumValidator extends BaseValidator
                 "https://schema.org/",
             ),
             "",
-            $value
+            $url
         );
 
-        $fqEnumClassname = $this->classname."\\".$enumValueClassname;
-
-        // $this->classname also represents the root namespace
-        // of the enum value classname,
-        // if a class with that namespace plus its name exists
-        // and has the same value passed to the validator, pass!
-        return class_exists($fqEnumClassname) &&
-            $fqEnumClassname::memberVal === $value;
+        return $this->classname."\\".$enumValueClassname;
     }
 }

--- a/src/Validators/EnumValidator.php
+++ b/src/Validators/EnumValidator.php
@@ -19,10 +19,28 @@ class EnumValidator extends BaseValidator
      * @param mixed $value The value to coerce.
      * @return int The coerced value
      */
-    // public function coerce($value)
-    // {
-    //     return $value;
-    // }
+    public function coerce($value)
+    {
+        if (! is_string($value)) {
+            return $value;
+        }
+
+        // Enum value is usually in a URL form
+        // Replace the base so that have a classname to use for the enum value
+        $enumValueClassname = str_replace(
+            array(
+                "https://openactive.io/ns-beta#",
+                "https://openactive.io/",
+                "https://schema.org/",
+            ),
+            "",
+            $value
+        );
+
+        $fqEnumClassname = $this->classname."\\".$enumValueClassname;
+
+        return new $fqEnumClassname();
+    }
 
     /**
      * Run validation on the given value.

--- a/src/Validators/EnumValidator.php
+++ b/src/Validators/EnumValidator.php
@@ -48,7 +48,7 @@ class EnumValidator extends BaseValidator
                 return false;
             }
 
-            $value = $value::memberVal;
+            $value = $memberVal;
         }
 
         // Enum value is usually in a URL form

--- a/src/Validators/EnumValidator.php
+++ b/src/Validators/EnumValidator.php
@@ -46,7 +46,7 @@ class EnumValidator extends BaseValidator
             if (
                 $memberVal === false ||
                 $reflection->getConstant('value') === false ||
-                strpos($classname, 'OpenActive\Enums\\') === 0
+                strpos($classname, 'OpenActive\Enums\\') !== 0
             ) {
                 return false;
             }

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -20,6 +20,10 @@ class EnumTest extends TestCase
         $session = new ScheduledSession($scheduledSessionData);
 
         $this->assertInstanceOf(ScheduledSession::class, $session);
+        $this->assertInstanceOf(
+            EventStatusType\EventCancelled::class,
+            $session->getEventStatus()
+        );
     }
 
     public function testConstructionFromStr()
@@ -34,6 +38,10 @@ class EnumTest extends TestCase
         $session = new ScheduledSession($scheduledsessionOptions);
 
         $this->assertInstanceOf(ScheduledSession::class, $session);
+        $this->assertInstanceOf(
+            EventStatusType\EventCancelled::class,
+            $session->getEventStatus()
+        );
     }
 
     public function testEnumSerialization()

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use OpenActive\Enums\SchemaOrg\EventStatusType;
+use OpenActive\Models\OA\ScheduledSession;
+
+class EnumTest extends TestCase
+{
+    public function testConstruction()
+    {
+        $eventStatus = new EventStatusType\EventCancelled();
+        $scheduledSessionData = [
+            'id' => '124',
+            'identifier' => '1234',
+            'duration' => 'PT1H',
+            'eventStatus' => $eventStatus
+        ];
+        $session = new ScheduledSession($scheduledSessionData);
+
+        $this->assertInstanceOf(ScheduledSession::class, $session);
+    }
+}

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -21,4 +21,25 @@ class EnumTest extends TestCase
 
         $this->assertInstanceOf(ScheduledSession::class, $session);
     }
+
+    public function testEnumSerialization()
+    {
+        $eventStatus = new EventStatusType\EventCancelled();
+        $scheduledSessionData = [
+            'id' => '124',
+            'identifier' => '1234',
+            'duration' => 'PT1H',
+            'eventStatus' => $eventStatus
+        ];
+        $session = new ScheduledSession($scheduledSessionData);
+
+        $classname = ScheduledSession::class;
+
+        $serializedData = json_decode($classname::serialize($session), true);
+
+        $this->assertEquals(
+            $serializedData['eventStatus'],
+            $eventStatus::memberVal
+        );
+    }
 }

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -8,7 +8,7 @@ use OpenActive\Models\OA\ScheduledSession;
 
 class EnumTest extends TestCase
 {
-    public function testConstruction()
+    public function testConstructionFromObj()
     {
         $eventStatus = new EventStatusType\EventCancelled();
         $scheduledSessionData = [
@@ -18,6 +18,20 @@ class EnumTest extends TestCase
             'eventStatus' => $eventStatus
         ];
         $session = new ScheduledSession($scheduledSessionData);
+
+        $this->assertInstanceOf(ScheduledSession::class, $session);
+    }
+
+    public function testConstructionFromStr()
+    {
+        $eventStatus = "https://schema.org/EventCancelled";
+        $scheduledsessionOptions = [
+            'id' => '124',
+            'identifier' => '1234',
+            'duration' => 'PT1H',
+            'eventStatus' => $eventStatus
+        ];
+        $session = new ScheduledSession($scheduledsessionOptions);
 
         $this->assertInstanceOf(ScheduledSession::class, $session);
     }


### PR DESCRIPTION
Allow for `EnumValidator` to pass on Enum objects, and also replaces `schema.org` namespace in URL check.

- [x] add support for Enum construction from object
- [x] add support for Enum construction from URL string
- [x] add Enum construction from object test
- [x] add Enum construction from string test
- [x] fix Enum serialization (return `memberVal`)
- [x] add Enum serialization unit test