### PR TITLE
Fix models failing with doctrine annotations

### DIFF
--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -18,7 +18,7 @@ class BaseModel implements SerializerInterface, TypeCheckerInterface
      * To be able to externally reference nodes in a graph, it is important that nodes have an identifier. IRIs
      * are a fundamental concept of Linked Data, for nodes to be truly linked, dereferencing the identifier should
      * result in a representation of that node.This may allow an application to retrieve further information about
-     * a node. In JSON-LD, a node is identified using the @id keyword:
+     * a node. In JSON-LD, a node is identified using the "@id" keyword:
      *
      * @var string
      */

--- a/src/Models/OA/Schedule.php
+++ b/src/Models/OA/Schedule.php
@@ -120,7 +120,7 @@ class Schedule extends \OpenActive\BaseModel
     protected $exceptDate;
 
     /**
-     * An RFC6570 compliant URI template that can be used to generate a unique identifier (@id) for every event described by the schedule (see below for more information). This property is required if the data provider is supporting third-party booking via the Open Booking API.
+     * An RFC6570 compliant URI template that can be used to generate a unique identifier ("@id") for every event described by the schedule (see below for more information). This property is required if the data provider is supporting third-party booking via the Open Booking API.
      *
      * ```json
      * "idTemplate": "https://example.com/event{/id}"

--- a/src/Models/OA/Slot.php
+++ b/src/Models/OA/Slot.php
@@ -265,7 +265,7 @@ class Slot extends \OpenActive\Models\OA\Event
     protected $eventStatus;
 
     /**
-     * FacilityUse or IndividualFacilityUse that has this offer, either directly embedded or referenced by its @id
+     * FacilityUse or IndividualFacilityUse that has this offer, either directly embedded or referenced by its "@id"
      *
      * ```json
      * "facilityUse": "https://example.com/facility-use/1"

--- a/src/Models/SchemaOrg/PropertyValueSpecification.php
+++ b/src/Models/SchemaOrg/PropertyValueSpecification.php
@@ -98,7 +98,7 @@ class PropertyValueSpecification extends \OpenActive\Models\SchemaOrg\Intangible
     protected $maxValue;
 
     /**
-     * Indicates the name of the PropertyValueSpecification to be used in URL templates and form encoding in a manner analogous to HTML's input@name.
+     * Indicates the name of the PropertyValueSpecification to be used in URL templates and form encoding in a manner analogous to HTML's "input@name".
      *
      *
      * @var string


### PR DESCRIPTION
Doctrine annotations are commonly used in many frameworks. This commit stops @ signs used in the context of JSON+LD being picked up as invalid annotations, allowing these classes to be used or extended in frameworks.

If for example you want to use these entities in Symfony using Doctrine, you would have to create a separate entity which contains these entities rather than being able to simply just extend the object and add the annotations required to store it in the Database.