### PR TITLE
Return empty items array for an empty page

### DIFF
--- a/src/Helpers/JsonLd.php
+++ b/src/Helpers/JsonLd.php
@@ -127,15 +127,16 @@ class JsonLd
         // Remove empty elements
         return array_filter(
             $data,
-            static function ($value) {
-                if (is_array($value) === true && count($value) === 0) {
+            static function ($value, $key) {
+                if (is_array($value) === true && count($value) === 0 && $key !== 'items') {
                     // Filter out empty arrays
                     return false;
                 }
 
                 // Filter out null values and empty strings
                 return $value !== null && $value !== "";
-            }
+            },
+            ARRAY_FILTER_USE_BOTH
         );
     }
 }

--- a/tests/Unit/RpdeTest.php
+++ b/tests/Unit/RpdeTest.php
@@ -50,6 +50,28 @@ class RpdeTest extends TestCase
     }
 
     /**
+     * Test the serialized RPDE body creates an empty items array
+     */
+    public function testCreateFromModifiedIdCreatesEmptyItemsArray()
+    {
+        $feed = RpdeBody::createFromModifiedId(
+            "https://www.example.com/feed",
+            1,
+            "1",
+            []
+        );
+
+        $this->assertEquals(
+            [
+                'next' => 'https://www.example.com/feed?afterTimestamp=1&afterId=1',
+                'items' => [],
+                'license' => 'https://creativecommons.org/licenses/by/4.0/'
+            ],
+            json_decode(RpdeBody::serialize($feed), true)
+        );
+    }
+
+    /**
      * Test the serialized RPDE body created with createFromNextChangeNumber returns the expected JSON-LD.
      *
      * @dataProvider jsonChangeNumberProvider


### PR DESCRIPTION
This PR fixes issue #48 where the `items` array is missing with empty pages