### PR TITLE
Improve type errors

### DIFF
--- a/src/Concerns/TypeChecker.php
+++ b/src/Concerns/TypeChecker.php
@@ -29,10 +29,33 @@ trait TypeChecker
 
         // If validation does not pass for any of the provided types,
         // type invalid
+        $location = self::getTypeCheckerErrorLocation();
         throw new InvalidArgumentException(
             "The first argument type does not match any of the declared parameter types (".
             implode(", ", $types).
-            ") for ".json_encode($value)."."
+            ") for ".json_encode($value)." at $location."
         );
+    }
+
+    /**
+     * This method retrieves an approximate location of the type error for debugging purposes. This enables the user to
+     * see at what location the validation failed
+     *
+     * @return string
+     */
+    private static function getTypeCheckerErrorLocation()
+    {
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $location = [];
+        $ns = 'OpenActive\\Models\\OA\\';
+        foreach ($trace as $call) {
+            if (0 !== strpos($call['class'], $ns)) {
+                continue;
+            }
+            $location[] = preg_replace('/set([A-Z])/', '$1', $call['function']);
+            $location[] = str_replace($ns, '', $call['class']);
+        }
+
+        return implode('.', array_reverse($location));
     }
 }

--- a/tests/Unit/Concerns/TypeCheckerTest.php
+++ b/tests/Unit/Concerns/TypeCheckerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit\Concerns;
+
+use OpenActive\Exceptions\InvalidArgumentException;
+use OpenActive\Models\OA\Order;
+use PHPUnit\Framework\TestCase;
+
+class TypeCheckerTest extends TestCase
+{
+    public function testRejectsInvalidType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The first argument type does not match any of the declared parameter types (\OpenActive\Models\OA\Organization) for "foo" at Order.Broker');
+        new Order([
+            'broker' => 'foo'
+        ]);
+    }
+
+    public function testRejectsInvalidTypeWithLocationInformation()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The first argument type does not match any of the declared parameter types (int, null) for "foo" at OrderItem.Position');
+
+        new Order([
+            'orderedItem' => [[
+                '@type' => 'OrderItem',
+                'position' => 'foo',
+            ]]
+        ]);
+    }
+
+    public function testRejectsInvalidTypeWithDeepLocationInformation()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The first argument type does not match any of the declared parameter types (string) for 509384 at Offer.Description');
+
+        new Order([
+            'orderedItem' => [[
+                '@type' => 'OrderItem',
+                'acceptedOffer' => [
+                    '@type' => 'Offer',
+                    'description' => 509384,
+                ],
+            ]]
+        ]);
+    }
+}


### PR DESCRIPTION
This changes the error message from:

`The first argument type does not match any of the declared parameter types (int, null) for "foo"`

to

`The first argument type does not match any of the declared parameter types (int, null) for "foo" at OrderItem.Position`

Which should give a user enough information to find out what particular type is the issue. Fixes #44 