### PR TITLE
Allow Orders and OrderProposals to be RPDE Serialized

### DIFF
--- a/src/Rpde/RpdeKind.php
+++ b/src/Rpde/RpdeKind.php
@@ -20,4 +20,6 @@ class RpdeKind
     const HEADLINE_EVENT = "HeadlineEvent";
     const EVENT = "Event";
     const EVENT_SERIES = "EventSeries";
+    const ORDER = "Order";
+    const ORDER_PROPOSAL = "OrderProposal";
 }

--- a/tests/Unit/RpdeResources/FacilityUses.php
+++ b/tests/Unit/RpdeResources/FacilityUses.php
@@ -1,0 +1,32 @@
+<?php
+
+use OpenActive\Rpde\RpdeItem;
+use OpenActive\Rpde\RpdeKind;
+use OpenActive\Rpde\RpdeState;
+use OpenActive\Models\OA as Models;
+
+return [
+    new RpdeItem([
+        "Id" => "1",
+        "Modified" => 4,
+        "State" => RpdeState::UPDATED,
+        "Kind" => RpdeKind::FACILITY_USE,
+        "Data" => new Models\FacilityUse([
+        ])
+    ]),
+    new RpdeItem([
+        "Id" => "2",
+        "Modified" => 4,
+        "State" => RpdeState::UPDATED,
+        "Kind" => RpdeKind::FACILITY_USE,
+        "Data" => new Models\FacilityUse([
+        ])
+    ]),
+    new RpdeItem([
+        "Id" => "3",
+        "Modified" => 5,
+        "State" => RpdeState::DELETED,
+        "Kind" => RpdeKind::FACILITY_USE,
+        "Data" => null
+    ])
+];

--- a/tests/Unit/RpdeResources/Orders.php
+++ b/tests/Unit/RpdeResources/Orders.php
@@ -1,0 +1,39 @@
+<?php
+
+use OpenActive\Rpde\RpdeItem;
+use OpenActive\Rpde\RpdeKind;
+use OpenActive\Rpde\RpdeState;
+use OpenActive\Models\OA as Models;
+
+return [
+    new RpdeItem([
+        "Id" => "1",
+        "Modified" => 4,
+        "State" => RpdeState::UPDATED,
+        "Kind" => RpdeKind::ORDER,
+        "Data" => new Models\Order([
+        ])
+    ]),
+    new RpdeItem([
+        "Id" => "2",
+        "Modified" => 4,
+        "State" => RpdeState::UPDATED,
+        "Kind" => RpdeKind::ORDER_PROPOSAL,
+        "Data" => new Models\OrderProposal([
+        ])
+    ]),
+    new RpdeItem([
+        "Id" => "3",
+        "Modified" => 5,
+        "State" => RpdeState::DELETED,
+        "Kind" => RpdeKind::ORDER,
+        "Data" => null
+    ]),
+    new RpdeItem([
+        "Id" => "4",
+        "Modified" => 5,
+        "State" => RpdeState::DELETED,
+        "Kind" => RpdeKind::ORDER_PROPOSAL,
+        "Data" => null
+    ])
+];

--- a/tests/Unit/RpdeResources/Slots.php
+++ b/tests/Unit/RpdeResources/Slots.php
@@ -1,0 +1,39 @@
+<?php
+
+use OpenActive\Rpde\RpdeItem;
+use OpenActive\Rpde\RpdeKind;
+use OpenActive\Rpde\RpdeState;
+use OpenActive\Models\OA as Models;
+
+return [
+    new RpdeItem([
+        "Id" => "1",
+        "Modified" => 4,
+        "State" => RpdeState::UPDATED,
+        "Kind" => RpdeKind::FACILITY_USE_SLOT,
+        "Data" => new Models\Slot([
+        ])
+    ]),
+    new RpdeItem([
+        "Id" => "2",
+        "Modified" => 4,
+        "State" => RpdeState::UPDATED,
+        "Kind" => RpdeKind::INDIVIDUAL_FACILITY_USE_SLOT,
+        "Data" => new Models\Slot([
+        ])
+    ]),
+    new RpdeItem([
+        "Id" => "3",
+        "Modified" => 5,
+        "State" => RpdeState::DELETED,
+        "Kind" => RpdeKind::FACILITY_USE_SLOT,
+        "Data" => null
+    ]),
+    new RpdeItem([
+        "Id" => "4",
+        "Modified" => 5,
+        "State" => RpdeState::DELETED,
+        "Kind" => RpdeKind::INDIVIDUAL_FACILITY_USE_SLOT,
+        "Data" => null
+    ])
+];

--- a/tests/Unit/RpdeResources/facility_uses.json
+++ b/tests/Unit/RpdeResources/facility_uses.json
@@ -1,0 +1,38 @@
+{
+  "next": "https://www.example.com/feed?afterTimestamp=5&afterId=3",
+  "items": [
+    {
+      "state": "updated",
+      "kind": "FacilityUse",
+      "id": "1",
+      "modified": 4,
+      "data": {
+        "@type": "FacilityUse",
+        "@context": [
+          "https://openactive.io/",
+          "https://openactive.io/ns-beta"
+        ]
+      }
+    },
+    {
+      "state": "updated",
+      "kind": "FacilityUse",
+      "id": "2",
+      "modified": 4,
+      "data": {
+        "@type": "FacilityUse",
+        "@context": [
+          "https://openactive.io/",
+          "https://openactive.io/ns-beta"
+        ]
+      }
+    },
+    {
+      "state": "deleted",
+      "kind": "FacilityUse",
+      "id": "3",
+      "modified": 5
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/tests/Unit/RpdeResources/orders.json
+++ b/tests/Unit/RpdeResources/orders.json
@@ -1,0 +1,44 @@
+{
+  "next": "https://www.example.com/feed?afterTimestamp=5&afterId=4",
+  "items": [
+    {
+      "state": "updated",
+      "kind": "Order",
+      "id": "1",
+      "modified": 4,
+      "data": {
+        "@type": "Order",
+        "@context": [
+          "https://openactive.io/",
+          "https://openactive.io/ns-beta"
+        ]
+      }
+    },
+    {
+      "state": "updated",
+      "kind": "OrderProposal",
+      "id": "2",
+      "modified": 4,
+      "data": {
+        "@type": "OrderProposal",
+        "@context": [
+          "https://openactive.io/",
+          "https://openactive.io/ns-beta"
+        ]
+      }
+    },
+    {
+      "state": "deleted",
+      "kind": "Order",
+      "id": "3",
+      "modified": 5
+    },
+    {
+      "state": "deleted",
+      "kind": "OrderProposal",
+      "id": "4",
+      "modified": 5
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/tests/Unit/RpdeResources/slots.json
+++ b/tests/Unit/RpdeResources/slots.json
@@ -1,0 +1,44 @@
+{
+  "next": "https://www.example.com/feed?afterTimestamp=5&afterId=4",
+  "items": [
+    {
+      "state": "updated",
+      "kind": "FacilityUse/Slot",
+      "id": "1",
+      "modified": 4,
+      "data": {
+        "@type": "Slot",
+        "@context": [
+          "https://openactive.io/",
+          "https://openactive.io/ns-beta"
+        ]
+      }
+    },
+    {
+      "state": "updated",
+      "kind": "IndividualFacilityUse/Slot",
+      "id": "2",
+      "modified": 4,
+      "data": {
+        "@type": "Slot",
+        "@context": [
+          "https://openactive.io/",
+          "https://openactive.io/ns-beta"
+        ]
+      }
+    },
+    {
+      "state": "deleted",
+      "kind": "FacilityUse/Slot",
+      "id": "3",
+      "modified": 5
+    },
+    {
+      "state": "deleted",
+      "kind": "IndividualFacilityUse/Slot",
+      "id": "4",
+      "modified": 5
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/tests/Unit/RpdeTest.php
+++ b/tests/Unit/RpdeTest.php
@@ -27,6 +27,26 @@ use PHPUnit\Framework\TestCase;
 class RpdeTest extends TestCase
 {
     /**
+     * @dataProvider allTypesDataProvider
+     * @param array $feed
+     * @param string $expectedJson
+     */
+    public function testCreatesSerializedRpdeFeedPageWithAllTypes($feed, $expectedJson)
+    {
+        $body = RpdeBody::createFromModifiedId(
+            'https://www.example.com/feed',
+            1,
+            "1",
+            $feed
+        );
+
+        $this->assertEquals(
+            json_decode($expectedJson),
+            json_decode(RpdeBody::serialize($body))
+        );
+    }
+
+    /**
      * Test the serialized RPDE body created with createFromModifiedId returns the expected JSON-LD.
      *
      * @dataProvider jsonAfterModifiedAfterIdProvider
@@ -684,6 +704,16 @@ class RpdeTest extends TestCase
                 "Kind" => RpdeKind::SESSION_SERIES,
                 "Data" => null
             ])
+        ];
+    }
+
+    public function allTypesDataProvider()
+    {
+        $res = __DIR__ . '/RpdeResources';
+        return [
+            [require $res . '/Orders.php', file_get_contents($res . '/orders.json')],
+            [require $res . '/FacilityUses.php', file_get_contents($res . '/facility_uses.json')],
+            [require $res . '/Slots.php', file_get_contents($res . '/slots.json')],
         ];
     }
 }


### PR DESCRIPTION
Adds the Order and OrderProposal objects so they can be Serialized by the RPDE Page serializer. Fixes #51 