### PR TITLE
Correct ending slash for schema.org

### DIFF
--- a/src/Helpers/JsonLd.php
+++ b/src/Helpers/JsonLd.php
@@ -75,7 +75,7 @@ class JsonLd
             )
         ) {
             $data["@context"] = array_merge(
-                $schema ? ['https://schema.org'] : [],
+                $schema ? ['https://schema.org/'] : [],
                 static::$defaultContext
             );
         }

--- a/tests/Unit/ExampleEventTest.php
+++ b/tests/Unit/ExampleEventTest.php
@@ -106,7 +106,7 @@ class ExampleEventTest extends TestCase
 
         $decoded = json_decode($encode, true);
 
-        $this->assertContains("https://schema.org", $decoded["@context"]);
+        $this->assertContains("https://schema.org/", $decoded["@context"]);
     }
 
     /**


### PR DESCRIPTION
When returning the `@context` it should contain `https://schema.org/` but it currently returns `https://schema.org`.