### PR TITLE
Add RpdeBody::deserialize() functionality

### DIFF
--- a/src/Concerns/TypeChecker.php
+++ b/src/Concerns/TypeChecker.php
@@ -48,12 +48,18 @@ trait TypeChecker
         $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
         $location = [];
         $ns = 'OpenActive\\Models\\OA\\';
+        $rpdeNs = 'OpenActive\\Rpde\\';
         foreach ($trace as $call) {
-            if (0 !== strpos($call['class'], $ns)) {
+            $loc = isset($call['class']) ? $call['class'] : '';
+            if (0 === strpos($loc, $rpdeNs) && !in_array($loc, $location)) {
+                $location[] = str_replace($ns, '', $loc);
+                continue;
+            }
+            if (0 !== strpos($loc, $ns)) {
                 continue;
             }
             $location[] = preg_replace('/set([A-Z])/', '$1', $call['function']);
-            $location[] = str_replace($ns, '', $call['class']);
+            $location[] = str_replace($ns, '', $loc);
         }
 
         return implode('.', array_reverse($location));

--- a/src/Rpde/RpdeBody.php
+++ b/src/Rpde/RpdeBody.php
@@ -50,12 +50,7 @@ class RpdeBody implements SerializerInterface, TypeCheckerInterface
     private function __construct($data)
     {
         foreach ($data as $key => $value) {
-            // Make sure setter is cased properly
-            $methodName = "set" . Str::pascal($key);
-
-            if (method_exists($this, $methodName) === true) {
-                $this->$methodName($value);
-            }
+            $this->defineProperty($key, $value);
         }
     }
 
@@ -300,9 +295,9 @@ class RpdeBody implements SerializerInterface, TypeCheckerInterface
      */
     public function setItems($items)
     {
-        $types = array(
+        $types = [
             "\OpenActive\Rpde\RpdeItem[]",
-        );
+        ];
 
         $items = self::checkTypes($items, $types);
 
@@ -330,5 +325,20 @@ class RpdeBody implements SerializerInterface, TypeCheckerInterface
         $license = self::checkTypes($license, $types);
 
         $this->license = $license;
+    }
+
+    public function defineProperty($key, $value)
+    {
+        // Ignore properties which start with @
+        if ('@' === $key{0}) {
+            return;
+        }
+
+        // Make sure setter is cased properly
+        $methodName = "set" . Str::pascal($key);
+
+        if (method_exists($this, $methodName) === true) {
+            $this->$methodName($value);
+        }
     }
 }

--- a/src/Rpde/RpdeItem.php
+++ b/src/Rpde/RpdeItem.php
@@ -176,6 +176,7 @@ class RpdeItem implements TypeCheckerInterface
     {
         $types = array(
             "\OpenActive\BaseModel",
+            "\\OpenActive\\Rpde\\RpdeItemData",
             "null",
         );
 

--- a/src/Validators/ArrayOfValidator.php
+++ b/src/Validators/ArrayOfValidator.php
@@ -26,20 +26,11 @@ class ArrayOfValidator extends BaseValidator
      */
     public function coerce($value)
     {
-        // NOTE: OpenActive is more strict than schema.org in this regard, so commenting out this for now
-        // $nullValidator = new NullValidator();
-
-        // If we are providing a single item of the itemValidator type (or null)
-        // Put the value inside an array
-        // if(
-        //     $nullValidator->run($value) === true ||
-        //     $this->itemValidator->run($value) === true
-        // ) {
-        //     return [$value];
-        // }
-
-        // Otherwise this is a no-op
-        return $value;
+        $newValue = [];
+        foreach ($value as $key => $item) {
+            $newValue[$key] = $this->itemValidator->coerce($item);
+        }
+        return $newValue;
     }
 
     /**
@@ -51,16 +42,6 @@ class ArrayOfValidator extends BaseValidator
     public function run($value)
     {
         $nullValidator = new NullValidator();
-
-        // NOTE: OpenActive is more strict than schema.org in this regard, so commenting out this for now
-        // If we are providing a single item of the itemValidator type (or null)
-        // Validation passes (but the value will need to be coerced to array)
-        // if(
-        //     $nullValidator->run($value) === true ||
-        //     $this->itemValidator->run($value) === true
-        // ) {
-        //     return true;
-        // }
 
         // Check if value is an array
         if ((new ArrayValidator())->run($value) === false) {

--- a/src/Validators/BaseValidator.php
+++ b/src/Validators/BaseValidator.php
@@ -90,6 +90,13 @@ class BaseValidator implements ValidatorInterface
             return new RpdeEnumValidator($type);
         }
 
+        if ($type === "\\OpenActive\\Rpde\\RpdeItem") {
+            return new RpdeItemValidator();
+        }
+        if ($type === "\\OpenActive\\Rpde\\RpdeItemData") {
+            return new RpdeItemDataValidator();
+        }
+
         // If type is an OpenActive BaseModel class
         if ($type === "\\OpenActive\\BaseModel") {
             return new BaseModelValidator();

--- a/src/Validators/RpdeItemDataValidator.php
+++ b/src/Validators/RpdeItemDataValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace OpenActive\Validators;
+
+use OpenActive\BaseModel;
+
+class RpdeItemDataValidator implements ValidatorInterface
+{
+    public function run($value)
+    {
+        if ($value instanceof BaseModel) {
+            return true;
+        }
+        if (null === $value) {
+            return true;
+        }
+        if (is_object($value)) {
+            $value = (array) $value;
+        }
+        return isset($value['@type'])
+            && null !== $this->getValidClass($value['@type']);
+    }
+
+    public function coerce($value)
+    {
+        if ($value instanceof BaseModel) {
+            return $value;
+        }
+        if (null === $value) {
+            return $value;
+        }
+
+        $class = $this->getValidClass($value['@type']);
+        if (null === $class) {
+            throw new \InvalidArgumentException(sprintf('Invalid type %s given, no instantiable class', $value['@type']));
+        }
+        return new $class($value);
+    }
+
+    private function getValidClass($type)
+    {
+        $classOa = sprintf('\\OpenActive\\Models\\OA\\%s', $type);
+        $classSchema = sprintf('\\OpenActive\\Models\\SchemaOrg\\%s', $type);
+
+        if (class_exists($classOa)) {
+            return $classOa;
+        }
+        if (class_exists($classSchema)) {
+            return $classSchema;
+        }
+        return null;
+    }
+}

--- a/src/Validators/RpdeItemValidator.php
+++ b/src/Validators/RpdeItemValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OpenActive\Validators;
+
+use OpenActive\Concerns\TypeChecker;
+use OpenActive\Rpde\RpdeItem;
+
+class RpdeItemValidator implements ValidatorInterface
+{
+    use TypeChecker;
+
+    public function run($value)
+    {
+        if ($value instanceof RpdeItem) {
+            return true;
+        }
+        if (is_object($value)) {
+            $value = (array) $value;
+        }
+
+        if (!isset($value['state'], $value['kind'], $value['id'], $value['modified'])) {
+            return false;
+        }
+
+        if ('deleted' === $value['state']) {
+            return true;
+        }
+
+        return isset($value['data']);
+    }
+
+    public function coerce($value)
+    {
+        if ($value instanceof RpdeItem) {
+            return $value;
+        }
+        return new RpdeItem($value);
+    }
+}

--- a/tests/Unit/RpdeTest.php
+++ b/tests/Unit/RpdeTest.php
@@ -45,6 +45,25 @@ class RpdeTest extends TestCase
             json_decode(RpdeBody::serialize($body))
         );
     }
+    /**
+     * @dataProvider allTypesDataProvider
+     * @param array $feed
+     * @param string $expectedJson
+     */
+    public function testAbleToUnserializeRpdeFeed($feed, $expectedJson)
+    {
+        $body = RpdeBody::createFromModifiedId(
+            'https://www.example.com/feed',
+            1,
+            "1",
+            $feed
+        );
+
+        $this->assertEquals(
+            $body,
+            RpdeBody::deserialize(RpdeBody::serialize($body))
+        );
+    }
 
     /**
      * Test the serialized RPDE body created with createFromModifiedId returns the expected JSON-LD.


### PR DESCRIPTION
Fixes #59

Had a few issues here in that the RpdeItem was always expecting instances of classes, and was doing its own Validation logic rather than using the `ValidationInterface`. In order to be able to deserialize properly I had to create two new Validators.

Not particularly happy with the amount of code I had to write for this, not sure if there's a better way of doing it without refactoring the entire instantiation logic of the RpdeBody and RpdeItem classes.