### PR TITLE
Reduce strictness on checks for Date/Time types

### DIFF
--- a/src/Helpers/DateTime.php
+++ b/src/Helpers/DateTime.php
@@ -22,7 +22,7 @@ class DateTime
             return $date->toISO8601();
         }
 
-        if ($date instanceof \DateTime === false) {
+        if (!$date instanceof \DateTime && !$date instanceof \DateTimeImmutable) {
             throw new \Exception("Invalid argument type.");
         }
 

--- a/src/Helpers/JsonLd.php
+++ b/src/Helpers/JsonLd.php
@@ -31,13 +31,13 @@ class JsonLd
         $fq_classname = "\\".get_class($obj);
 
         // Get interval spec string, e.g. "P1D"
-        if($fq_classname === "\\DateInterval") {
+        if($obj instanceof \DateInterval) {
             return DateIntervalHelper::specString($obj);
         }
 
         // Get ISO 8601 date time representation,
         // e.g. "2019-01-01T00:00:00-08:00"
-        if($fq_classname === "\\DateTime") {
+        if($obj instanceof \DateTime || $obj instanceof \DateTimeImmutable) {
             return DateTimeHelper::iso8601($obj);
         }
 

--- a/tests/Unit/Helpers/DateIntervalExtension.php
+++ b/tests/Unit/Helpers/DateIntervalExtension.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit\Helpers;
+
+class DateIntervalExtension extends \DateInterval
+{
+}

--- a/tests/Unit/Helpers/DateTimeExtension.php
+++ b/tests/Unit/Helpers/DateTimeExtension.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit\Helpers;
+
+class DateTimeExtension extends \DateTime
+{
+}

--- a/tests/Unit/Helpers/JsonLdTest.php
+++ b/tests/Unit/Helpers/JsonLdTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit\Helpers;
+
+use OpenActive\Helpers\JsonLd;
+use PHPUnit\Framework\TestCase;
+
+class JsonLdTest extends TestCase
+{
+    /**
+     * @param $dateTime
+     * @dataProvider dateTimeProvider
+     */
+    public function testSerializesDateTimes($dateTime)
+    {
+        $this->assertEquals('2020-01-01T11:00:00+00:00', JsonLd::prepareDataForSerialization($dateTime));
+    }
+
+    /**
+     * @param $dateInterval
+     * @dataProvider dateIntervalProvider
+     */
+    public function testSerializesDateIntervals($dateInterval)
+    {
+        $this->assertEquals('P1DT1H', JsonLd::prepareDataForSerialization($dateInterval));
+    }
+
+    public function dateTimeProvider()
+    {
+        return [
+            [new \DateTime('2020-01-01T11:00:00+00:00')],
+            [new \DateTimeImmutable('2020-01-01T11:00:00+00:00')],
+            [new DateTimeExtension('2020-01-01T11:00:00+00:00')],
+        ];
+    }
+
+    public function dateIntervalProvider()
+    {
+        return [
+            [new \DateInterval('P1DT1H')],
+            [new DateIntervalExtension('P1DT1H')],
+        ];
+    }
+}


### PR DESCRIPTION
Fixes #55

It's been mentioned that extensions of the default `\DateTime` objects in PHP aren't getting picked up as valid Date objects by the JsonLd serialization process. This is an issue because you can correctly instantiate an OA model with these types but it fails at the serialization step.

This PR also adds support for `\DateTimeImmutable`, and possible extensions on `\DateInterval` classes.