### PR TITLE
Remove deprecated string offset

### DIFF
--- a/src/Rpde/RpdeBody.php
+++ b/src/Rpde/RpdeBody.php
@@ -330,7 +330,7 @@ class RpdeBody implements SerializerInterface, TypeCheckerInterface
     public function defineProperty($key, $value)
     {
         // Ignore properties which start with @
-        if ('@' === $key{0}) {
+        if ('@' === $key[0]) {
             return;
         }
 


### PR DESCRIPTION
This has been deprecated and will be removed (I think) in PHP 8.