### PR TITLE
Add PHP8 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .php_cs.cache
 .phpunit.result.cache
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 php:
   - '5.6'
   - '7.3'
+  - '7.4'
+  - '8.0'
 install:
   - composer install
 script: ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ OpenActive aims to provide model files for all classes defined in its Opportunit
     - [Models](#models)
         - [OpenActive](#openactive)
         - [Schema.org](#schemaorg)
+        
     - [RPDE](#rpde)
     - [Enums](#enums)
     - [Serialization](#serialization)
@@ -19,7 +20,6 @@ OpenActive aims to provide model files for all classes defined in its Opportunit
 
 ## Requirements
 This project requires PHP >=5.6.
-While most of the functionality should work down to PHP 5.4, some functionality (especially around parsing of offset for DateTimeZone) will not work with that version of PHP (see the [DateTimeZone PHP docs](https://www.php.net/manual/en/datetimezone.construct.php#refsect1-datetimezone.construct-changelog) for more info).
 
 ## Installation
 To install via Composer, from terminal, run:
@@ -367,7 +367,7 @@ composer install
 ```
 
 ### Running Tests
-PHPUnit 5.7 is used to run tests.
+PHPUnit is used to run tests.
 
 To run the whole suite:
 ```bash
@@ -385,7 +385,7 @@ You can also run a section of the suite by specifying the class's relative path 
 ```
 
 For additional information on the commands available for PHPUnit,
-consult [their documentation](https://phpunit.de/manual/5.7/en/installation.html)
+consult [their documentation](https://phpunit.readthedocs.io/en/8.5/textui.html#command-line-options)
 
 
 ### Updating models

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,11 @@
 {
   "name": "openactive/models",
+  "description": "Library for working with the Openactive Specification",
   "type": "library",
   "license": "MIT",
+  "require": {
+    "php": "^5.6 | ^7.0 | ^8.0"
+  },
   "autoload": {
     "psr-4": {
       "OpenActive\\": "src/"
@@ -15,7 +19,7 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15",
     "squizlabs/php_codesniffer": "^3.5",
-    "phpunit/phpunit": "^5.7"
+    "phpunit/phpunit": "^5.7 | ^9.0"
   },
   "scripts": {
     "fix": "./vendor/bin/php-cs-fixer fix",

--- a/tests/Unit/Validators/TimeValidatorTest.php
+++ b/tests/Unit/Validators/TimeValidatorTest.php
@@ -9,12 +9,12 @@ class TimeValidatorTest extends TestCase
 {
     public function testValidTimeReturnsTrue()
     {
-        assert((new TimeValidator())->run("12:00:00"), "TimeValidator should allow valid ISO 8601 times");
+        $this->assertTrue((new TimeValidator())->run("12:00:00"), "TimeValidator should allow valid ISO 8601 times");
     }
 
     public function testInvalidTimeReturnsFalse()
     {
-        assert(!(new TimeValidator())->run("not a time"), "TimeValidator should disallow invalid ISO 8601 times");
+        $this->assertFalse((new TimeValidator())->run("not a time"), "TimeValidator should disallow invalid ISO 8601 times");
     }
 }
 


### PR DESCRIPTION
With the latest release of [PHP 8](https://www.php.net/releases/8.0/en.php) we should add support for this so that people can use this library in more recent versions. I have run the tests and they complete successfully. Also dropped support for PHP 5 as the active user-base for 5.6 has dropped to [<3%](https://blog.packagist.com/php-versions-stats-2020-2-edition/).