### PR TITLE
Allow Serialization/Deserialization modifications

### DIFF
--- a/tests/Unit/ExampleEventTest.php
+++ b/tests/Unit/ExampleEventTest.php
@@ -138,6 +138,50 @@ class ExampleEventTest extends TestCase
         $this->assertSame($encode, $reencode);
     }
 
+    public function testSerializeOfferEncodeWithModifications()
+    {
+        $offer = new Offer([
+            "Id" => "https://www.example.com/event_offer/12345_201803180430",
+            "Url" => "https://www.example.com/event_offer/12345_201803180430",
+            "Price" => 30.32,
+            "PriceCurrency" => "USD",
+            "ValidFrom" => new \DateTime(
+                "2017-01-20 16:20:00",
+                new \DateTimeZone("-0800")
+            )
+        ]);
+
+        $encoded = Offer::serialize($offer, true, false, [
+            function ($class, $attr, $value) {
+                if ($class !== '\\' . Offer::class) {
+                    return $value;
+                }
+                if ($attr !== 'price') {
+                    return $value;
+                }
+                return (string) $value;
+            },
+            function ($class, $attr, $value) {
+                if ($attr !== 'priceCurrency') {
+                    return $value;
+                }
+                return 'GBP';
+            }
+        ]);
+        $this->assertEquals(json_encode([
+            '@type' => 'Offer',
+            '@context' => [
+                'https://openactive.io/',
+                'https://openactive.io/ns-beta'
+            ],
+            '@id' => 'https://www.example.com/event_offer/12345_201803180430',
+            'url' => 'https://www.example.com/event_offer/12345_201803180430',
+            'priceCurrency' => 'GBP',
+            'price' => "30.32",
+            'validFrom' => '2017-01-20T16:20:00-08:00'
+        ], JSON_PRETTY_PRINT), $encoded);
+    }
+
     /**
      * Returns an array of arrays.
      * Each item contains a classname and the deserialized representation

--- a/tests/Unit/RpdeResources/orders-modified.json
+++ b/tests/Unit/RpdeResources/orders-modified.json
@@ -1,0 +1,47 @@
+{
+  "next": "https://www.example.com/feed?afterTimestamp=5&afterId=4",
+  "items": [
+    {
+      "state": "updated",
+      "kind": "Order",
+      "id": "1",
+      "modified": 4,
+      "data": {
+        "@type": "Order",
+        "@context": [
+          "https://openactive.io/",
+          "https://openactive.io/ns-beta"
+        ]
+      }
+    },
+    {
+      "state": "updated",
+      "kind": "OrderProposal",
+      "id": "2",
+      "modified": 4,
+      "data": {
+        "@type": "OrderProposal",
+        "@context": [
+          "https://openactive.io/",
+          "https://openactive.io/ns-beta"
+        ],
+        "extra": {
+          "foo": "bar"
+        }
+      }
+    },
+    {
+      "state": "deleted",
+      "kind": "Order",
+      "id": "3",
+      "modified": 5
+    },
+    {
+      "state": "deleted",
+      "kind": "OrderProposal",
+      "id": "4",
+      "modified": 5
+    }
+  ],
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/tests/Unit/RpdeTest.php
+++ b/tests/Unit/RpdeTest.php
@@ -631,6 +631,34 @@ class RpdeTest extends TestCase
         );
     }
 
+    /**
+     * @dataProvider serializationModifiersDataProvider
+     * @param array $feed
+     * @param string $expectedJson
+     */
+    public function testAppliesModificationsAfterSerialization($feed, $expectedJson)
+    {
+        $body = RpdeBody::createFromModifiedId(
+            'https://www.example.com/feed',
+            1,
+            "1",
+            $feed
+        );
+
+        $this->assertEquals(
+            json_decode($expectedJson),
+            json_decode(RpdeBody::serialize($body, false, false, [
+                function ($class, $key, $value) {
+                    if ('data' !== $key || !is_array($value) || 'OrderProposal' !== $value['@type']) {
+                        return $value;
+                    }
+                    $value['extra'] = ['foo' => 'bar'];
+                    return $value;
+                }
+            ]))
+        );
+    }
+
     public function jsonAfterModifiedAfterIdProvider()
     {
         $data = array();
@@ -755,6 +783,14 @@ class RpdeTest extends TestCase
             [require $res . '/Orders.php', file_get_contents($res . '/orders.json')],
             [require $res . '/FacilityUses.php', file_get_contents($res . '/facility_uses.json')],
             [require $res . '/Slots.php', file_get_contents($res . '/slots.json')],
+        ];
+    }
+
+    public function serializationModifiersDataProvider()
+    {
+        $res = __DIR__ . '/RpdeResources';
+        return [
+            [require $res . '/Orders.php', file_get_contents($res . '/orders-modified.json')],
         ];
     }
 }


### PR DESCRIPTION
This allows providing a fourth parameter to `serialize` and a second parameter to `deserialize` to handle cases where you need to modify the request or responses when communicating with a third party. An example of this is when library changes happen and the third party has not updated yet, or if their data is incorrect and needs to be fixed before bringing into the data models. Also perhaps a case where their booking API doesn't accept correct responses so as a Broker you need to make vendor-specific modifications.