### PR TITLE
Fix beta type model resolution

### DIFF
--- a/src/BaseModel.php
+++ b/src/BaseModel.php
@@ -133,7 +133,9 @@ class BaseModel implements SerializerInterface, TypeCheckerInterface
                 $classname = "\\OpenActive\\Models\\SchemaOrg\\".
                     str_replace("schema:", "", $type);
             } else {
-                $classname = "\\OpenActive\\Models\\OA\\".$type;
+                $classname = "\\OpenActive\\Models\\OA\\".
+                    // If the type is in beta, remove the prefix to resolve the model
+                    str_replace("beta:", "", $type);
             }
 
             return $classname::deserialize($value);


### PR DESCRIPTION
Fixes errors such as `Class "\OpenActive\Models\OA\beta:Bar" not found` when attempting to output feeds containing beta types.