### PR TITLE
Update test to use JSON comparison

### DIFF
--- a/tests/Unit/ExampleEventTest.php
+++ b/tests/Unit/ExampleEventTest.php
@@ -33,9 +33,9 @@ class ExampleEventTest extends TestCase
 
         $jsonEvent = $classname::serialize($event);
 
-        $this->assertEquals(
-            json_decode($json, true),
-            json_decode($jsonEvent, true)
+        $this->assertJsonStringEqualsJsonString(
+            $json,
+            $jsonEvent
         );
     }
 
@@ -65,9 +65,9 @@ class ExampleEventTest extends TestCase
         $decode = Concept::deserialize($original);
         $encode = Concept::serialize($decode);
 
-        $this->assertEquals(
-            json_decode($original, true),
-            json_decode($encode, true)
+        $this->assertJsonStringEqualsJsonString(
+            $original,
+            $encode
         );
     }
 
@@ -85,9 +85,9 @@ class ExampleEventTest extends TestCase
         $decode = Concept::deserialize($original);
         $encode = Concept::serialize($decode);
 
-        $this->assertEquals(
-            json_decode($expected, true),
-            json_decode($encode, true)
+        $this->assertJsonStringEqualsJsonString(
+            $expected,
+            $encode
         );
     }
 
@@ -135,7 +135,7 @@ class ExampleEventTest extends TestCase
 
         // output.WriteLine($encode);
         // output.WriteLine($reencode);
-        $this->assertSame($encode, $reencode);
+        $this->assertJsonStringEqualsJsonString($encode, $reencode);
     }
 
     public function testSerializeOfferEncodeWithModifications()
@@ -168,7 +168,7 @@ class ExampleEventTest extends TestCase
                 return 'GBP';
             }
         ]);
-        $this->assertEquals(json_encode([
+        $this->assertJsonStringEqualsJsonString(json_encode([
             '@type' => 'Offer',
             '@context' => [
                 'https://openactive.io/',


### PR DESCRIPTION
This Fixes an issue where if the order of the properties changed
as the comparison was being done between two strings, it would
fail the tests. This moves this to using the inbuilt PHPUnit method
for JSON comparison.