### PR TITLE
Pass the object into the modifier call

### DIFF
--- a/src/Helpers/JsonLd.php
+++ b/src/Helpers/JsonLd.php
@@ -127,7 +127,7 @@ class JsonLd
             $data[$attrName] = $attrValue;
 
             foreach ($modifiers as $modifier) {
-                $data[$attrName] = $modifier($fq_classname, $attrName, $data[$attrName]);
+                $data[$attrName] = $modifier($fq_classname, $attrName, $data[$attrName], $obj);
             }
         }
 


### PR DESCRIPTION
Pass the object currently being serialized into the modifier call so that the modifier callable has access to the object's context. This will allow the modifier to make modifications to a value based on the current state of the object being modified. For example it allows optional computation of a duration from a start and end date if present.

As discussed on a call with @nathansalter yesterday.