### PR TITLE
Add Modifier Object context

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ OpenActive aims to provide model files for all classes defined in its Opportunit
     - [Serialization](#serialization)
         - [`serialize($obj, $prettyPrint = false)`](#serializeobj-prettyprint--false)
         - [`deserialize($data)`](#deserializedata)
+        - [Modifiers](#modifiers)
 - [Contributing](#contributing)
 
 ## Requirements
@@ -366,7 +367,7 @@ date format you could do this:
 use OpenActive\Models\OA\SessionSeries;
 
 echo SessionSeries::serialize($sessionSeries, true, false, [
-    function ($class, $key, $value) {
+    function ($class, $key, $value, $object) {
       if (!in_array($key, ['startDate', 'endDate'])) {
         return $value;
       }
@@ -378,12 +379,14 @@ echo SessionSeries::serialize($sessionSeries, true, false, [
 The given modifiers **MUST** adhere to this method signature:
 
 ```
-function (string $class, string $key, mixed $value): mixed
+function (string $class, string $key, mixed $value, mixed $object): mixed
 ```
 
 Each modifier **MUST** always respond with a value, as the modifiers are always applied. If it does not return a value
 all the data in your object will be wiped during serialization. You **SHOULD** use the `$class` and `$key` parameters to
-determine if the modifier should run for the parameter, and simply return the `$value` if it is not necessary.
+determine if the modifier should run for the parameter, and simply return the `$value` if it is not necessary. The
+`$object` parameter is also available for modifiers which require further information from the 
+parent object.
 
 Modifiers can also be added to the Deserialization process, and are applied *before* the property is set. This can be
 useful when having to handle migration paths as changes happen in the library, or to fix data coming from an
@@ -394,7 +397,7 @@ you could do this:
 use OpenActive\Models\OA\SessionSeries;
 
 $session = SessionSeries::deserialize('{...}', [
-    function ($class, $key, $value) {
+    function ($class, $key, $value, $object) {
       if (!in_array($key, ['startDate', 'endDate'])) {
         return $value;
       }
@@ -402,6 +405,8 @@ $session = SessionSeries::deserialize('{...}', [
     }
 ]);
 ```
+
+Example & helper modifiers can be found in the `src/Modifiers` directory.
 
 ## Contributing
 

--- a/src/Concerns/Serializer.php
+++ b/src/Concerns/Serializer.php
@@ -64,7 +64,7 @@ trait Serializer
 
         foreach ($data as $key => $value) {
             foreach ($modifiers as $modifier) {
-                $value = $modifier($class, $key, $value);
+                $value = $modifier($class, $key, $value, $self);
             }
             $self->defineProperty($key, $value);
         }

--- a/src/Helpers/JsonLd.php
+++ b/src/Helpers/JsonLd.php
@@ -127,7 +127,7 @@ class JsonLd
             $data[$attrName] = $attrValue;
 
             foreach ($modifiers as $modifier) {
-                $data[$attrName] = $modifier($fq_classname, $attrName, $data[$attrName]);
+                $data[$attrName] = $modifier($fq_classname, $attrName, $data[$attrName], $obj);
             }
         }
 

--- a/src/Modifiers/TimezoneNormalizerModifier.php
+++ b/src/Modifiers/TimezoneNormalizerModifier.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OpenActive\Modifiers;
+
+use OpenActive\Helpers\DateTime as DateTimeHelper;
+
+class TimezoneNormalizerModifier
+{
+    /** @var string */
+    private $timezone;
+
+    /**
+     * @var string $timezone
+     */
+    public function __construct($timezone)
+    {
+        $this->timezone = $timezone;
+    }
+
+    public function __invoke($class, $key, $value, $object)
+    {
+        if (!in_array($key, ['startDate', 'endDate'])) {
+            return $value;
+        }
+        $tzDate = new \DateTime($value);
+        $tzDate->setTimezone(new \DateTimeZone($this->timezone));
+        return DateTimeHelper::iso8601($tzDate);
+    }
+}

--- a/tests/Unit/Modifiers/TimezoneNormalizerModifierTest.php
+++ b/tests/Unit/Modifiers/TimezoneNormalizerModifierTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OpenActive\Models\Tests\Unit\Modifiers;
+
+use OpenActive\Models\OA\Slot;
+use OpenActive\Modifiers\TimezoneNormalizerModifier;
+use PHPUnit\Framework\TestCase;
+
+class TimezoneNormalizerModifierTest extends TestCase
+{
+    public function testAddsTimezoneToSlot()
+    {
+        $slot = new Slot([
+            'startDate' => '2020-06-01T10:00:00+00:00',
+            'endDate' => '2020-06-01T11:00:00+00:00',
+        ]);
+        $serialized = Slot::serialize($slot, false, false, [
+            new TimezoneNormalizerModifier('Europe/London')
+        ]);
+        $decoded = json_decode($serialized, true);
+        $this->assertEquals('2020-06-01T11:00:00+01:00', $decoded['startDate']);
+        $this->assertEquals('2020-06-01T12:00:00+01:00', $decoded['endDate']);
+    }
+
+    public function testConvertsSlotBackToUTC()
+    {
+        $serialized = Slot::serialize(new Slot([
+            'startDate' => '2020-06-01T11:00:00+01:00',
+            'endDate' => '2020-06-01T12:00:00+01:00',
+        ]));
+        /** @var Slot $slot */
+        $slot = Slot::deserialize($serialized, [
+            new TimezoneNormalizerModifier('Europe/London')
+        ]);
+        $this->assertEquals(new \DateTime('2020-06-01T10:00:00+00:00'), $slot->getStartDate());
+        $this->assertEquals(new \DateTime('2020-06-01T11:00:00+00:00'), $slot->getEndDate());
+    }
+}


### PR DESCRIPTION
This adds the `$object` context to modifiers, and adds a useful helper for normalizing a DateTime to the required Timezone.