### PR TITLE
Make it compatible with PHP 8.2

### DIFF
--- a/src/Validators/BaseValidator.php
+++ b/src/Validators/BaseValidator.php
@@ -4,7 +4,10 @@ namespace OpenActive\Validators;
 
 class BaseValidator implements ValidatorInterface
 {
-    protected string $classname;
+    /**
+    * @var string
+    */
+    protected $classname;
 
     /**
      * Coerce given value to the type the validator is validating against.

--- a/src/Validators/BaseValidator.php
+++ b/src/Validators/BaseValidator.php
@@ -4,6 +4,8 @@ namespace OpenActive\Validators;
 
 class BaseValidator implements ValidatorInterface
 {
+    protected string $classname;
+
     /**
      * Coerce given value to the type the validator is validating against.
      * PLEASE NOTE: no checks are performed on the given $value.


### PR DESCRIPTION
This prevent the deprecated error:

`Creation of dynamic property OpenActive\\Validators\\RpdeEnumValidator::$classname is deprecated`