### PR TITLE
fix: Remove the test case for the `Date` type on the `startDate` property of `Event`

### DIFF
--- a/tests/Unit/Formatting/DateTest.php
+++ b/tests/Unit/Formatting/DateTest.php
@@ -69,23 +69,6 @@ class DateTest extends TestCase
         $this->assertEquals($expected, $serialized);
     }
 
-    function testEventDate() {
-        $schedule = new Event(["startDate" => "2019-11-29"]);
-
-        $serialized = Event::toArray($schedule);
-
-        $expected = [
-            "@type" => "Event",
-            "@context" => [
-                "https://openactive.io/",
-                "https://openactive.io/ns-beta"
-            ],
-            "startDate" => "2019-11-29"
-        ];
-
-        $this->assertEquals($expected, $serialized);
-    }
-
     function testEventDateTime() {
         $schedule = new Event(["startDate" => "2019-11-29T10:00:00Z"]);
 


### PR DESCRIPTION
Following [this fix](https://github.com/openactive/data-models/commit/a49e829223d738ce5bf089c9d735455fe9a8937e) and https://github.com/openactive/modelling-opportunity-data/issues/314, this PR ensures that the tests continue to pass.