### PR TITLE
fix: Avoid dynamic properties not allowed error and include 8.2 in CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['5.6', '7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php-versions }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['5.6', '7.3', '7.4', '8.0']
+        php-versions: ['5.6', '7.3', '7.4', '8.0', '8.2']
     name: PHP ${{ matrix.php-versions }}
     steps:
     - name: Checkout

--- a/src/Validators/EnumValidator.php
+++ b/src/Validators/EnumValidator.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 
 class EnumValidator extends BaseValidator
 {
+    private $classname;
     public function __construct($classname)
     {
         $this->classname = $classname;
@@ -17,7 +18,7 @@ class EnumValidator extends BaseValidator
      * It is therefore recommended to call the "run" method first before this.
      *
      * @param mixed $value The value to coerce.
-     * @return int The coerced value
+     * @return mixed The coerced value
      */
     public function coerce($value)
     {

--- a/src/Validators/EnumValidator.php
+++ b/src/Validators/EnumValidator.php
@@ -6,7 +6,11 @@ use ReflectionClass;
 
 class EnumValidator extends BaseValidator
 {
-    private $classname;
+    /**
+    * @var string
+    */
+    protected $classname;
+    
     public function __construct($classname)
     {
         $this->classname = $classname;

--- a/src/Validators/InstanceValidator.php
+++ b/src/Validators/InstanceValidator.php
@@ -4,6 +4,7 @@ namespace OpenActive\Validators;
 
 class InstanceValidator extends BaseValidator
 {
+    private $classname;
     public function __construct($classname)
     {
         $this->classname = $classname;

--- a/src/Validators/InstanceValidator.php
+++ b/src/Validators/InstanceValidator.php
@@ -4,7 +4,11 @@ namespace OpenActive\Validators;
 
 class InstanceValidator extends BaseValidator
 {
-    private $classname;
+    /**
+    * @var string
+    */
+    protected $classname;
+    
     public function __construct($classname)
     {
         $this->classname = $classname;

--- a/src/Validators/RpdeEnumValidator.php
+++ b/src/Validators/RpdeEnumValidator.php
@@ -4,6 +4,7 @@ namespace OpenActive\Validators;
 
 class RpdeEnumValidator extends BaseValidator
 {
+    private $classname;
     public function __construct($classname)
     {
         $this->classname = $classname;

--- a/src/Validators/RpdeEnumValidator.php
+++ b/src/Validators/RpdeEnumValidator.php
@@ -4,7 +4,11 @@ namespace OpenActive\Validators;
 
 class RpdeEnumValidator extends BaseValidator
 {
-    private $classname;
+    /**
+    * @var string
+    */
+    protected $classname;
+    
     public function __construct($classname)
     {
         $this->classname = $classname;


### PR DESCRIPTION
From https://github.com/playfinder/models-php/pull/2 - updated to use "protected" rather than "private", and to run against 8.2 in CI